### PR TITLE
build: Use golang-action v0.10.1 with Task to run CI steps concurrently remote and locally

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: schubergphilis/mcvs-golang-action@v0.9.4
+      - uses: schubergphilis/mcvs-golang-action@v0.10.1
         with:
           code-coverage-expected: 62.3
           gci: "false"

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -10,14 +10,26 @@ permissions:
   contents: read
   packages: read
 jobs:
-  mcvs-golang-action:
+  MCVS-golang-action:
+    env:
+      TASK_X_REMOTE_TASKFILES: 1
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4.2.1
-      - uses: schubergphilis/mcvs-golang-action@v0.8.3
+      - uses: actions/checkout@v4.2.2
+      - uses: schubergphilis/mcvs-golang-action@v0.9.4
         with:
-          code_coverage_expected: 62.3
+          code-coverage-expected: 62.3
           gci: "false"
           golang-unit-tests-exclusions: |-
             \(cmd\/prolayout\)
           golangci-lint-version: v1.61.0
+          testing-type: ${{ matrix.testing-type }}
+    strategy:
+      matrix:
+        testing-type:
+          - coverage
+          - lint
+          - security-golang-modules
+          - security-grype
+          - security-trivy
+          - unit

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.task
 .vscode
 reports

--- a/README.md
+++ b/README.md
@@ -1,12 +1,25 @@
 # ProLayout
 
-Pro(ject) layout is a static analysis tool that allow you to lint the project structure of your go project.
+Pro(ject) layout is a static analysis tool that allow you to lint the project
+structure of your go project.
 
-# Why
+## Development
 
-Since Go does not enforce any real project structure, we wanted to have a static analysis tool, to help us to ensure projects are structured in a similar fashion. 
+Either use `make` or `task`:
 
-# Example configuration file
+### Task
+
+```zsh
+TASK_X_REMOTE_TASKFILES=1 task test-all --yes
+```
+
+## Why
+
+Since Go does not enforce any real project structure, we wanted to have a
+static analysis tool, to help us to ensure projects are structured in a similar
+fashion.
+
+## Example configuration file
 
 ```YAML
 module: "github.com/wimspaargaren/prolayout"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,17 @@
+---
+version: 3
+
+vars:
+  REMOTE_URL: https://raw.githubusercontent.com
+  REMOTE_URL_REF: v0.9.4
+  REMOTE_URL_REPO: schubergphilis/mcvs-golang-action
+
+includes:
+  remote: >-
+    {{.REMOTE_URL}}/{{.REMOTE_URL_REPO}}/{{.REMOTE_URL_REF}}/Taskfile.yml
+
+tasks:
+  test-all:
+    deps:
+      - task: remote:golangci-lint
+      - task: remote:test


### PR DESCRIPTION
* Use remote Taskfile to avoid code duplication in Makefiles.
* Use Taskfile to run CI steps concurrently.
* Run the same steps, both remote in CICD as locally to get more predictable results.