### PR TITLE
fix: Bug in go-mod-updater - dependencies label unknown

### DIFF
--- a/.github/workflows/gomod-go-version-updater.yml
+++ b/.github/workflows/gomod-go-version-updater.yml
@@ -11,4 +11,4 @@ jobs:
   gomod-go-version-updater-action:
     runs-on: ubuntu-22.04
     steps:
-      - uses: schubergphilis/gomod-go-version-updater-action@v0.1.5
+      - uses: schubergphilis/gomod-go-version-updater-action@v0.1.7


### PR DESCRIPTION
* go-mod-updater was not able to generate labels, blocking the creation of PRs that will update the go version.